### PR TITLE
Implement Comment Update and Destroy APIs and Unit Tests

### DIFF
--- a/comments/api/permissions.py
+++ b/comments/api/permissions.py
@@ -1,0 +1,19 @@
+from rest_framework.permissions import BasePermission
+
+
+class IsObjectOwner(BasePermission):
+    """
+    This class is to check if obj.user == request.user.
+    Permissions will be called one by one:
+    - if action has detail=False, this class will only check has_permission();
+    - if action has detail=True, this class will check both
+      has_permission() and has_object_permission().
+    If the user has no permissions, then the below message will be shown.
+    """
+    message = 'You do not have permission to access this object.'
+
+    def has_permission(self, request, view):
+        return True
+
+    def has_object_permission(self, request, view, obj):
+        return request.user == obj.user

--- a/comments/api/serializers.py
+++ b/comments/api/serializers.py
@@ -49,3 +49,15 @@ class CommentCreateSerializer(serializers.ModelSerializer):
             tweet_id=validated_data['tweet_id'],
             content=validated_data['content'],
         )
+
+
+class CommentUpdateSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Comment
+        fields = ('content',)
+
+    def update(self, instance, validated_data):
+        instance.content = validated_data['content']
+        instance.save()
+        # the update method must return the updated instance
+        return instance

--- a/comments/api/tests.py
+++ b/comments/api/tests.py
@@ -1,7 +1,10 @@
 from testing.testcases import TestCase
 from rest_framework.test import APIClient
+from django.utils import timezone
+from comments.models import Comment
 
 COMMENT_URL = '/api/comments/'
+COMMENT_DETAIL_URL = '/api/comments/{}/'
 
 
 class CommentApiTests(TestCase):
@@ -50,5 +53,55 @@ class CommentApiTests(TestCase):
         self.assertEqual(response.data['user']['id'], self.user1.id)
         self.assertEqual(response.data['tweet_id'], self.tweet.id)
         self.assertEqual(response.data['content'], '2')
+
+    def test_destroy(self):
+        comment = self.create_comment(self.user1, self.tweet)
+        url = COMMENT_DETAIL_URL.format(comment.id)
+
+        # must log in to delete comment
+        response = self.anonymous_client.delete(url)
+        self.assertEqual(response.status_code, 403)
+
+        # must be the user who owns the comment to be able to delete
+        response = self.user2_client.delete(url)
+        self.assertEqual(response.status_code, 403)
+
+        # user who POST the original comment can delete it
+        count = Comment.objects.count()
+        response = self.user1_client.delete(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(Comment.objects.count(), count - 1)
+
+    def test_update(self):
+        comment = self.create_comment(self.user1, self.tweet, 'original')
+        another_tweet = self.create_tweet(self.user2)
+        url = COMMENT_DETAIL_URL.format(comment.id)
+
+        # must log in to update comment
+        response = self.anonymous_client.put(url, {'content': 'new'})
+        self.assertEqual(response.status_code, 403)
+        # must be the user to update comment
+        response = self.user2_client.put(url, {'content': 'new'})
+        self.assertEqual(response.status_code, 403)
+        comment.refresh_from_db()
+        self.assertNotEqual(comment.content, 'new')
+        # can only update content, nothing else
+        before_updated_at = comment.updated_at
+        before_created_at = comment.created_at
+        now = timezone.now()
+        response = self.user1_client.put(url, {
+            'content': 'new',
+            'user_id': self.user2.id,
+            'tweet_id': another_tweet.id,
+            'created_at': now,
+        })
+        self.assertEqual(response.status_code, 200)
+        comment.refresh_from_db()
+        self.assertEqual(comment.content, 'new')
+        self.assertEqual(comment.user, self.user1)
+        self.assertEqual(comment.tweet, self.tweet)
+        self.assertEqual(comment.created_at, before_created_at)
+        self.assertNotEqual(comment.created_at, now)
+        self.assertNotEqual(comment.updated_at, before_updated_at)
 
 

--- a/comments/api/views.py
+++ b/comments/api/views.py
@@ -75,6 +75,7 @@ class CommentViewSet(viewsets.GenericViewSet):
             status=status.HTTP_200_OK,
         )
 
+    # DELETE
     def destroy(self, request, *args, **kwargs):
         comment = self.get_object()
         comment.delete()

--- a/comments/api/views.py
+++ b/comments/api/views.py
@@ -5,7 +5,10 @@ from comments.models import Comment
 from comments.api.serializers import (
     CommentSerializer,
     CommentCreateSerializer,
+    CommentUpdateSerializer,
 )
+from comments.api.permissions import IsObjectOwner
+
 
 class CommentViewSet(viewsets.GenericViewSet):
     """
@@ -25,6 +28,8 @@ class CommentViewSet(viewsets.GenericViewSet):
     def get_permissions(self):
         if self.action == 'create':
             return [IsAuthenticated()]
+        if self.action in ['update', 'destroy']:
+            return [IsAuthenticated(), IsObjectOwner()]
         return [AllowAny()]
 
     def create(self, request, *args, **kwargs):
@@ -48,3 +53,33 @@ class CommentViewSet(viewsets.GenericViewSet):
             status=status.HTTP_201_CREATED,
         )
 
+    def update(self, request, *args, **kwargs):
+        # get_object() is a function of Django Rest Framework.
+        # If the object is not found, DRF will automatically raise 404 error.
+        comment = self.get_object()
+        serializer = CommentUpdateSerializer(
+            instance=comment,
+            data=request.data,
+        )
+        if not serializer.is_valid():
+            raise Response({
+                'message': 'Please check input.',
+                'errors': serializer.errors,
+            }, status=status.HTTP_400_BAD_REQUEST)
+        # Here, save() will call the update method in serializer.
+        # save() will call create or update depending on
+        # whether the instance parameter is passed to serializer.
+        comment = serializer.save()
+        return Response(
+            CommentSerializer(comment).data,
+            status=status.HTTP_200_OK,
+        )
+
+    def destroy(self, request, *args, **kwargs):
+        comment = self.get_object()
+        comment.delete()
+        # In DRF, the default return status of destroy is
+        # status code = 204 no content.
+        # Here, we return success=True for the front end user
+        # and HTTP_200_OK is more appropriate.
+        return Response({'success': True}, status=status.HTTP_200_OK)


### PR DESCRIPTION
- Added comments/permissions.py to validate users before updating and destroying comments.
- Added update serializer "CommentUpdateSerializer" in comments/serializers.py; added update in comments/views.py.
- Added destroy in comments/views.py.
- Added unit tests to test Comment Update and Destroy APIs.
