### PR TITLE
Implement Tweet Retrive API to get tweet with comments

### DIFF
--- a/comments/api/views.py
+++ b/comments/api/views.py
@@ -8,7 +8,7 @@ from comments.api.serializers import (
     CommentUpdateSerializer,
 )
 from comments.api.permissions import IsObjectOwner
-
+from utils.decorators import required_params
 
 class CommentViewSet(viewsets.GenericViewSet):
     """
@@ -33,12 +33,8 @@ class CommentViewSet(viewsets.GenericViewSet):
             return [IsAuthenticated(), IsObjectOwner()]
         return [AllowAny()]
 
+    @required_params(params=['tweet_id'])
     def list(self, request, *args, **kwargs):
-        if 'tweet_id' not in request.query_params:
-            return Response({
-                    'message': 'missing tweet_id in request',
-                    'success': False,
-                }, status=status.HTTP_400_BAD_REQUEST)
         queryset = self.get_queryset()
         comments = self.filter_queryset(queryset)\
             .prefetch_related('user')\

--- a/tweets/api/serializers.py
+++ b/tweets/api/serializers.py
@@ -1,6 +1,8 @@
 from rest_framework import serializers
 from tweets.models import Tweet
 from accounts.api.serializers import UserSerializerForTweet
+from comments.api.serializers import CommentSerializer
+
 
 class TweetSerializer(serializers.ModelSerializer):
     user = UserSerializerForTweet()
@@ -22,3 +24,12 @@ class TweetCreateSerializer(serializers.ModelSerializer):
         content = validated_data['content']
         tweet = Tweet.objects.create(user=user, content=content)
         return tweet
+
+
+class TweetSerializerWithComments(TweetSerializer):
+    comments = CommentSerializer(source='comment_set', many=True)
+
+    class Meta:
+        model = Tweet
+        fields = ('id', 'user', 'created_at', 'content', 'comments')
+

--- a/tweets/api/views.py
+++ b/tweets/api/views.py
@@ -1,9 +1,14 @@
 from rest_framework import viewsets
 from rest_framework.permissions import IsAuthenticated, AllowAny
 from rest_framework.response import Response
-from tweets.api.serializers import TweetSerializer, TweetCreateSerializer
+from tweets.api.serializers import (
+    TweetSerializer,
+    TweetCreateSerializer,
+    TweetSerializerWithComments,
+)
 from tweets.models import Tweet
 from newsfeeds.services import NewsFeedService
+from utils.decorators import required_params
 
 class TweetViewSet(viewsets.GenericViewSet,
                    viewsets.mixins.CreateModelMixin,
@@ -15,23 +20,27 @@ class TweetViewSet(viewsets.GenericViewSet,
     serializer_class = TweetCreateSerializer
 
     def get_permissions(self):
-        if self.action == 'list':
+        if self.action in ['list', 'retrieve']:
             return [AllowAny()]
         return [IsAuthenticated()]
 
+    def retrieve(self, request, *args, **kwargs):
+        tweet = self.get_object()
+        return Response(TweetSerializerWithComments(tweet).data)
+
+    @required_params(params=['user_id'])
+    # GET request.query_params
+    # POST request.data
     def list(self, request, *args, **kwargs):
         """
         This list method needs to include user_id to filter tweet contents.
         """
-        if 'user_id' not in request.query_params:
-            return Response('missing user_id', status=400)
-
-        # equals to
+        # Equals to
         # select * from twitter_tweets
         # where user_id = xx
         # order by created_at DESC
-        user_id = request.query_params['user_id']
-        tweets = Tweet.objects.filter(user_id=user_id)\
+        tweets = Tweet.objects.filter(
+            user_id=request.query_params['user_id'])\
             .prefetch_related('user')\
             .order_by('-created_at')
         serializer = TweetSerializer(tweets, many=True)
@@ -46,14 +55,12 @@ class TweetViewSet(viewsets.GenericViewSet,
             data=request.data,
             context={'request': request},
         )
-
         if not serializer.is_valid():
             return Response({
                 "success": False,
                 "message": "Please check input.",
                 "errors": serializer.errors,
             }, status=400)
-
         # serializer.save() will call create method in TweetCreateSerializer
         tweet = serializer.save()
         NewsFeedService.fanout_to_followers(tweet)

--- a/utils/decorators.py
+++ b/utils/decorators.py
@@ -1,0 +1,39 @@
+from rest_framework.response import Response
+from rest_framework import status
+from functools import wraps
+
+
+def required_params(request_attr='query_params', params=None):
+    """
+    The required_params function will wrap the view function in views.py and
+    return a decorator after we call @required_params(params=['some_param']).
+    """
+    if params is None:
+        params = []
+
+    def decorator(view_func):
+        """
+        Here, the decorator send the parameters of the view function
+        to _wrapped_view via wraps.
+        The instance parameter is self in view_func.
+        """
+        @wraps(view_func)
+        def _wrapped_view(instance, request, *args, **kwargs):
+            # getattr can get both data and queries
+            data = getattr(request, request_attr)
+            missing_params = [
+                param
+                for param in params
+                if param not in data
+            ]
+            if missing_params:
+                params_str = ','.join(missing_params)
+                return Response({
+                    'message': u'missing {} in request'.format(params_str),
+                    'success': False,
+                }, status=status.HTTP_400_BAD_REQUEST)
+            # view_func (wrapped by @required_params) will be called after
+            # these validations
+            return view_func(instance, request, *args, **kwargs)
+        return _wrapped_view
+    return decorator


### PR DESCRIPTION
- Added retrieve API in tweet to get tweet with comments (retrieve in tweets/view.py and TweetSerializerWithComment in tweets/serializers.py).
- Added decorator (required_params) to validate parameters before calling list API in tweets/views.py and comments/views.py.
- Ran unit tests for tweet retrieve API.