### PR TITLE
Insert Likes Info to Tweet and Comment APIs

### DIFF
--- a/accounts/api/serializers.py
+++ b/accounts/api/serializers.py
@@ -1,6 +1,7 @@
 from django.contrib.auth.models import User
 from rest_framework import serializers, exceptions
 
+
 class UserSerializer(serializers.ModelSerializer):
     class Meta:
         model = User
@@ -11,6 +12,10 @@ class UserSerializerForTweet(serializers.ModelSerializer):
     class Meta:
         model = User
         fields = ('id', 'username')
+
+
+class UserSerializerForLike(UserSerializerForTweet):
+    pass
 
 
 class UserSerializerForComment(UserSerializerForTweet):

--- a/comments/api/serializers.py
+++ b/comments/api/serializers.py
@@ -1,5 +1,6 @@
 from accounts.api.serializers import UserSerializerForComment
 from comments.models import Comment
+from likes.services import LikeService
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
 from tweets.models import Tweet
@@ -9,6 +10,8 @@ class CommentSerializer(serializers.ModelSerializer):
     # if we don't add user = UserSerializer() here,
     # the 'user' in fields will be shown as user_id.
     user = UserSerializerForComment()
+    has_liked = serializers.SerializerMethodField()
+    likes_count = serializers.SerializerMethodField()
 
     class Meta:
         model = Comment
@@ -18,8 +21,15 @@ class CommentSerializer(serializers.ModelSerializer):
             'user',
             'content',
             'created_at',
-            'updated_at',
+            'likes_count',
+            'has_liked',
         )
+
+    def get_likes_count(self, obj):
+        return obj.like_set.count()
+
+    def get_has_liked(self, obj):
+        return LikeService.has_liked(self.context['request'].user, obj)
 
 
 class CommentCreateSerializer(serializers.ModelSerializer):

--- a/comments/api/tests.py
+++ b/comments/api/tests.py
@@ -1,10 +1,12 @@
-from testing.testcases import TestCase
-from rest_framework.test import APIClient
-from django.utils import timezone
 from comments.models import Comment
+from django.utils import timezone
+from testing.testcases import TestCase
 
 COMMENT_URL = '/api/comments/'
 COMMENT_DETAIL_URL = '/api/comments/{}/'
+TWEET_LIST_API = '/api/tweets/'
+TWEET_DETAIL_API = '/api/tweets/{}/'
+NEWSFEED_LIST_API = '/api/newsfeeds/'
 
 
 class CommentApiTests(TestCase):
@@ -127,5 +129,26 @@ class CommentApiTests(TestCase):
             'user_id': self.user1.id,
         })
         self.assertEqual(len(response.data['comments']), 2)
+
+    def test_comments_count(self):
+        # test tweet detail api
+        tweet = self.create_tweet(self.user1)
+        url = TWEET_DETAIL_API.format(tweet.id)
+        response = self.user2_client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['comments_count'], 0)
+
+        # test tweet list api
+        self.create_comment(self.user1, tweet)
+        response = self.user2_client.get(TWEET_LIST_API, {'user_id': self.user1.id})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['tweets'][0]['comments_count'], 1)
+
+        # test newsfeeds list api
+        self.create_comment(self.user2, tweet)
+        self.create_newsfeed(self.user2, tweet)
+        response = self.user2_client.get(NEWSFEED_LIST_API)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['newsfeeds'][0]['tweet']['comments_count'], 2)
 
 

--- a/comments/api/views.py
+++ b/comments/api/views.py
@@ -1,14 +1,15 @@
-from rest_framework import viewsets, status
-from rest_framework.response import Response
-from rest_framework.permissions import IsAuthenticated, AllowAny
-from comments.models import Comment
+from comments.api.permissions import IsObjectOwner
 from comments.api.serializers import (
     CommentSerializer,
     CommentCreateSerializer,
     CommentUpdateSerializer,
 )
-from comments.api.permissions import IsObjectOwner
+from comments.models import Comment
+from rest_framework import viewsets, status
+from rest_framework.permissions import IsAuthenticated, AllowAny
+from rest_framework.response import Response
 from utils.decorators import required_params
+
 
 class CommentViewSet(viewsets.GenericViewSet):
     """
@@ -41,7 +42,11 @@ class CommentViewSet(viewsets.GenericViewSet):
             .order_by('created_at')
         #tweet_id = request.query_params['tweet_id']
         #comments = Comment.objects.filter(tweet_id=tweet_id)
-        serializer = CommentSerializer(comments, many=True)
+        serializer = CommentSerializer(
+            comments,
+            context={'request': request},
+            many=True
+        )
         return Response(
             {'comments': serializer.data},
             status=status.HTTP_200_OK,
@@ -64,7 +69,7 @@ class CommentViewSet(viewsets.GenericViewSet):
         # .save() will call the create method in serializer
         comment = serializer.save()
         return Response(
-            CommentSerializer(comment).data,
+            CommentSerializer(comment, context={'request': request}).data,
             status=status.HTTP_201_CREATED,
         )
 
@@ -86,7 +91,7 @@ class CommentViewSet(viewsets.GenericViewSet):
         # whether the instance parameter is passed to serializer.
         comment = serializer.save()
         return Response(
-            CommentSerializer(comment).data,
+            CommentSerializer(comment, context={'request': request}).data,
             status=status.HTTP_200_OK,
         )
 

--- a/likes/api/serializers.py
+++ b/likes/api/serializers.py
@@ -1,4 +1,4 @@
-from accounts.api.serializers import UserSerializer
+from accounts.api.serializers import UserSerializerForLike
 from comments.models import Comment
 from django.contrib.contenttypes.models import ContentType
 from likes.models import Like
@@ -8,7 +8,7 @@ from tweets.models import Tweet
 
 
 class LikeSerializer(serializers.ModelSerializer):
-    user = UserSerializer()
+    user = UserSerializerForLike()
 
     class Meta:
         model = Like

--- a/likes/api/tests.py
+++ b/likes/api/tests.py
@@ -1,8 +1,11 @@
 from testing.testcases import TestCase
 
-
 LIKE_BASE_URL = '/api/likes/'
 LIKE_CANCEL_URL = '/api/likes/cancel/'
+COMMENT_LIST_API = '/api/comments/'
+TWEET_LIST_API = '/api/tweets/'
+TWEET_DETAIL_API = '/api/tweets/{}/'
+NEWSFEED_LIST_API = '/api/newsfeeds/'
 
 
 class LikeApiTests(TestCase):
@@ -150,3 +153,67 @@ class LikeApiTests(TestCase):
         self.assertEqual(response.data['deleted'], 1)
         self.assertEqual(tweet.like_set.count(), 0)
         self.assertEqual(comment.like_set.count(), 0)
+
+    def test_likes_in_comments_api(self):
+        tweet = self.create_tweet(self.user1)
+        comment = self.create_comment(self.user1, tweet)
+
+        # test anonymous
+        response = self.anonymous_client.get(COMMENT_LIST_API, {'tweet_id': tweet.id})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['comments'][0]['has_liked'], False)
+        self.assertEqual(response.data['comments'][0]['likes_count'], 0)
+
+        # test comments list api
+        response = self.user2_client.get(COMMENT_LIST_API, {'tweet_id': tweet.id})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['comments'][0]['has_liked'], False)
+        self.assertEqual(response.data['comments'][0]['likes_count'], 0)
+        self.create_like(self.user2, comment)
+        response = self.user2_client.get(COMMENT_LIST_API, {'tweet_id': tweet.id})
+        self.assertEqual(response.data['comments'][0]['has_liked'], True)
+        self.assertEqual(response.data['comments'][0]['likes_count'], 1)
+
+        # test tweet detail api
+        self.create_like(self.user1, comment)
+        url = TWEET_DETAIL_API.format(tweet.id)
+        response = self.user2_client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['comments'][0]['has_liked'], True)
+        self.assertEqual(response.data['comments'][0]['likes_count'], 2)
+
+    def test_likes_in_tweets_api(self):
+        tweet = self.create_tweet(self.user1)
+
+        # test tweet detail api
+        url = TWEET_DETAIL_API.format(tweet.id)
+        response = self.user2_client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['has_liked'], False)
+        self.assertEqual(response.data['likes_count'], 0)
+        self.create_like(self.user2, tweet)
+        response = self.user2_client.get(url)
+        self.assertEqual(response.data['has_liked'], True)
+        self.assertEqual(response.data['likes_count'], 1)
+
+        # test tweets list api
+        response = self.user2_client.get(TWEET_LIST_API, {'user_id': self.user1.id})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['tweets'][0]['has_liked'], True)
+        self.assertEqual(response.data['tweets'][0]['likes_count'], 1)
+
+        # test newsfeeds list api
+        self.create_like(self.user1, tweet)
+        self.create_newsfeed(self.user2, tweet)
+        response = self.user2_client.get(NEWSFEED_LIST_API)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['newsfeeds'][0]['tweet']['has_liked'], True)
+        self.assertEqual(response.data['newsfeeds'][0]['tweet']['likes_count'], 2)
+
+        # test likes details
+        url = TWEET_DETAIL_API.format(tweet.id)
+        response = self.user2_client.get(url)
+        self.assertEqual(len(response.data['likes']), 2)
+        self.assertEqual(response.data['likes'][0]['user']['id'], self.user1.id)
+        self.assertEqual(response.data['likes'][1]['user']['id'], self.user2.id)
+

--- a/likes/models.py
+++ b/likes/models.py
@@ -1,7 +1,7 @@
-from django.db import models
 from django.contrib.auth.models import User
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
+from django.db import models
 
 
 class Like(models.Model):
@@ -22,7 +22,10 @@ class Like(models.Model):
         # different types of objects.
         unique_together = (('user', 'content_type', 'object_id'),)
         # This index_together will create index for all likes of a content_object.
-        index_together = (('content_type', 'object_id', 'created_at'),)
+        index_together = (
+            ('content_type', 'object_id', 'created_at'),
+            ('user', 'content_type', 'created_at'),
+        )
 
     def __str__(self):
         return '{} - {} liked {} {}'.format(

--- a/likes/services.py
+++ b/likes/services.py
@@ -1,0 +1,15 @@
+from django.contrib.contenttypes.models import ContentType
+from likes.models import Like
+
+
+class LikeService(object):
+
+    @classmethod
+    def has_liked(cls, user, target):
+        if user.is_anonymous:
+            return False
+        return Like.objects.filter(
+            content_type = ContentType.objects.get_for_model(target.__class__),
+            object_id = target.id,
+            user=user,
+        ).exists()

--- a/newsfeeds/api/views.py
+++ b/newsfeeds/api/views.py
@@ -2,8 +2,8 @@ from rest_framework import viewsets, status
 from rest_framework.decorators import permission_classes
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
-from newsfeeds.models import NewsFeed
 from newsfeeds.api.serializers import NewsFeedSerializer
+from newsfeeds.models import NewsFeed
 
 class NewsFeedViewSet(viewsets.GenericViewSet):
     permission_classes = [IsAuthenticated]
@@ -13,7 +13,11 @@ class NewsFeedViewSet(viewsets.GenericViewSet):
         return NewsFeed.objects.filter(user=self.request.user)
 
     def list(self, request):
-        serializer = NewsFeedSerializer(self.get_queryset(), many=True)
+        serializer = NewsFeedSerializer(
+            self.get_queryset(),
+            context={'request': request},
+            many=True,
+        )
         return Response({
             'newsfeeds': serializer.data,
         }, status=status.HTTP_200_OK)

--- a/testing/testcases.py
+++ b/testing/testcases.py
@@ -1,10 +1,11 @@
-from django.test import TestCase as DjangoTestCase
-from django.contrib.auth.models import User
-from tweets.models import Tweet
-from rest_framework.test import APIClient
 from comments.models import Comment
-from likes.models import Like
+from django.contrib.auth.models import User
 from django.contrib.contenttypes.models import ContentType
+from django.test import TestCase as DjangoTestCase
+from likes.models import Like
+from newsfeeds.models import NewsFeed
+from rest_framework.test import APIClient
+from tweets.models import Tweet
 
 
 class TestCase(DjangoTestCase):
@@ -50,4 +51,7 @@ class TestCase(DjangoTestCase):
         client = APIClient()
         client.force_authenticate(user)
         return user, client
+
+    def create_newsfeed(self, user, tweet):
+        return NewsFeed.objects.create(user=user, tweet=tweet)
 

--- a/tweets/api/serializers.py
+++ b/tweets/api/serializers.py
@@ -1,15 +1,56 @@
-from rest_framework import serializers
-from tweets.models import Tweet
 from accounts.api.serializers import UserSerializerForTweet
 from comments.api.serializers import CommentSerializer
+from likes.services import LikeService
+from likes.api.serializers import LikeSerializer
+from rest_framework import serializers
+from tweets.models import Tweet
 
 
 class TweetSerializer(serializers.ModelSerializer):
     user = UserSerializerForTweet()
+    comments_count = serializers.SerializerMethodField()
+    likes_count = serializers.SerializerMethodField()
+    has_liked = serializers.SerializerMethodField()
 
     class Meta:
         model = Tweet
-        fields = ('id', 'user', 'created_at', 'content')
+        fields = (
+            'id',
+            'user',
+            'created_at',
+            'content',
+            'comments_count',
+            'likes_count',
+            'has_liked',
+        )
+
+    def get_likes_count(self, obj):
+        return obj.like_set.count()
+
+    def get_comments_count(self, obj):
+        return obj.comment_set.count()
+
+    def get_has_liked(self, obj):
+        return LikeService.has_liked(self.context['request'].user, obj)
+
+
+class TweetSerializerForDetail(TweetSerializer):
+    comments = CommentSerializer(source='comment_set', many=True)
+    likes = LikeSerializer(source='like_set', many=True)
+
+    class Meta:
+        model = Tweet
+        fields = (
+            'id',
+            'user',
+            'comments',
+            'created_at',
+            'content',
+            'likes',
+            'comments_count',
+            'likes_count',
+            'has_liked',
+        )
 
 
 class TweetCreateSerializer(serializers.ModelSerializer):
@@ -26,10 +67,5 @@ class TweetCreateSerializer(serializers.ModelSerializer):
         return tweet
 
 
-class TweetSerializerWithComments(TweetSerializer):
-    comments = CommentSerializer(source='comment_set', many=True)
 
-    class Meta:
-        model = Tweet
-        fields = ('id', 'user', 'created_at', 'content', 'comments')
 


### PR DESCRIPTION
- Added has_liked in likes/services.py to check if the content has been liked
- Added Likes Info (including 'has_liked', 'likes_count', 'comments_count') to Tweet API (TweetSerializer and TweetSerializerForDetail)
- Added Likes Info to Comment API (CommentSerializer)
- Ran unit tests for these changes.