### PR TITLE
Add TweetPhoto API

### DIFF
--- a/tweets/api/serializers.py
+++ b/tweets/api/serializers.py
@@ -1,9 +1,12 @@
 from accounts.api.serializers import UserSerializerForTweet
 from comments.api.serializers import CommentSerializer
-from likes.services import LikeService
 from likes.api.serializers import LikeSerializer
+from likes.services import LikeService
 from rest_framework import serializers
+from rest_framework.exceptions import ValidationError
+from tweets.constants import TWEET_PHOTOS_UPLOAD_LIMIT
 from tweets.models import Tweet
+from tweets.services import TweetService
 
 
 class TweetSerializer(serializers.ModelSerializer):
@@ -11,6 +14,7 @@ class TweetSerializer(serializers.ModelSerializer):
     comments_count = serializers.SerializerMethodField()
     likes_count = serializers.SerializerMethodField()
     has_liked = serializers.SerializerMethodField()
+    photo_urls = serializers.SerializerMethodField()
 
     class Meta:
         model = Tweet
@@ -22,6 +26,7 @@ class TweetSerializer(serializers.ModelSerializer):
             'comments_count',
             'likes_count',
             'has_liked',
+            'photo_urls',
         )
 
     def get_likes_count(self, obj):
@@ -32,6 +37,12 @@ class TweetSerializer(serializers.ModelSerializer):
 
     def get_has_liked(self, obj):
         return LikeService.has_liked(self.context['request'].user, obj)
+
+    def get_photo_urls(self, obj):
+        photo_urls = []
+        for photo in obj.tweetphoto_set.all().order_by('order'):
+            photo_urls.append(photo.file.url)
+        return photo_urls
 
 
 class TweetSerializerForDetail(TweetSerializer):
@@ -50,20 +61,39 @@ class TweetSerializerForDetail(TweetSerializer):
             'comments_count',
             'likes_count',
             'has_liked',
+            'photo_urls',
         )
 
 
-class TweetCreateSerializer(serializers.ModelSerializer):
+class TweetSerializerForCreate(serializers.ModelSerializer):
     content = serializers.CharField(min_length=6, max_length=140)
+    files = serializers.ListField(
+        child=serializers.FileField(),
+        allow_empty=True,
+        required=False,
+    )
 
     class Meta:
         model = Tweet
-        fields = ('content',)
+        fields = ('content', 'files')
+
+    def validate(self, data):
+        if len(data.get('files', [])) > TWEET_PHOTOS_UPLOAD_LIMIT:
+            raise ValidationError({
+                'message': f'You can upload {TWEET_PHOTOS_UPLOAD_LIMIT} '
+                            'photos at most.'
+            })
+        return data
 
     def create(self, validated_data):
         user = self.context['request'].user
         content = validated_data['content']
         tweet = Tweet.objects.create(user=user, content=content)
+        if validated_data.get('files'):
+            TweetService.create_photos_from_files(
+                tweet,
+                validated_data['files'],
+            )
         return tweet
 
 

--- a/tweets/api/tests.py
+++ b/tweets/api/tests.py
@@ -1,6 +1,6 @@
-from rest_framework.test import APIClient
+from django.core.files.uploadedfile import SimpleUploadedFile
 from testing.testcases import TestCase
-from tweets.models import Tweet
+from tweets.models import Tweet, TweetPhoto
 
 # must include '/' at the end, otherwise will return 301 redirect
 TWEET_LIST_API = '/api/tweets/'
@@ -81,4 +81,75 @@ class TweetApiCase(TestCase):
         self.create_comment(self.user1, self.create_tweet(self.user2), "...")
         response = self.anonymous_client.get(url)
         self.assertEqual(len(response.data['comments']), 2)
+
+    def test_create_with_files(self):
+        # create a tweet without files
+        response = self.user1_client.post(TWEET_CREATE_API, {
+            'content': 'a selfie',
+        })
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(TweetPhoto.objects.count(), 0)
+
+        # Upload an empty list of files
+        response = self.user1_client.post(TWEET_CREATE_API, {
+            'content': 'a selfie',
+            'file': []
+        })
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(TweetPhoto.objects.count(), 0)
+
+        # Upload single file
+        # content requires byte type; str.encode can convert str to byte.
+        file = SimpleUploadedFile(
+            name='selfie.jpg',
+            content=str.encode('a fake image'),
+            content_type='image/jpeg',
+        )
+        response = self.user1_client.post(TWEET_CREATE_API, {
+            'content': 'a selfie',
+            'files': [file],
+        })
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(TweetPhoto.objects.count(), 1)
+
+        # Upload multiple files
+        file1 = SimpleUploadedFile(
+            name='selfie1.jpg',
+            content=str.encode('selfie 1'),
+            content_type='image/jpeg',
+        )
+        file2 = SimpleUploadedFile(
+            name='selfie2.jpg',
+            content=str.encode('selfie 2'),
+            content_type='image/jpeg',
+        )
+        response =self.user1_client.post(TWEET_CREATE_API, {
+            'content': 'two selfies.',
+            'files': [file1, file2],
+        })
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(TweetPhoto.objects.count(), 3)
+
+        # GET the photo_url in API
+        retrieve_url = TWEET_RETRIEVE_API.format(response.data['id'])
+        response = self.user1_client.get(retrieve_url)
+        self.assertEqual(len(response.data['photo_urls']), 2)
+        self.assertEqual('selfie1' in response.data['photo_urls'][0], True)
+        self.assertEqual('selfie2' in response.data['photo_urls'][1], True)
+
+        # Fails to upload over 9 files
+        files = [
+            SimpleUploadedFile(
+                name=f'selfie{i}.jpg',
+                content=str.encode(f'selfie{i}'),
+                content_type='image/jpeg',
+            )
+            for i in range(10)
+        ]
+        response = self.user1_client.post(TWEET_CREATE_API, {
+            'content': 'failed due to number of photos exceeded limit',
+            'files': files,
+        })
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(TweetPhoto.objects.count(), 3)
 

--- a/tweets/api/views.py
+++ b/tweets/api/views.py
@@ -4,11 +4,12 @@ from rest_framework.permissions import IsAuthenticated, AllowAny
 from rest_framework.response import Response
 from tweets.api.serializers import (
     TweetSerializer,
-    TweetCreateSerializer,
+    TweetSerializerForCreate,
     TweetSerializerForDetail,
 )
 from tweets.models import Tweet
 from utils.decorators import required_params
+
 
 class TweetViewSet(viewsets.GenericViewSet,
                    viewsets.mixins.CreateModelMixin,
@@ -17,7 +18,7 @@ class TweetViewSet(viewsets.GenericViewSet,
     API endpoint that allows users to create, list tweets
     """
     queryset = Tweet.objects.all()
-    serializer_class = TweetCreateSerializer
+    serializer_class = TweetSerializerForCreate
 
     def get_permissions(self):
         if self.action in ['list', 'retrieve']:
@@ -59,7 +60,7 @@ class TweetViewSet(viewsets.GenericViewSet,
         """
         This create method needs current user as tweet.user
         """
-        serializer = TweetCreateSerializer(
+        serializer = TweetSerializerForCreate(
             data=request.data,
             context={'request': request},
         )

--- a/tweets/constants.py
+++ b/tweets/constants.py
@@ -4,9 +4,12 @@ class TweetPhotoStatus:
     REJECTED = 2
 
 
-
 TWEET_PHOTO_STATUS_CHOICES = (
     (TweetPhotoStatus.PENDING, 'Pending'),
     (TweetPhotoStatus.APPROVED, 'Approved'),
     (TweetPhotoStatus.REJECTED, 'Rejected'),
 )
+
+
+TWEET_PHOTOS_UPLOAD_LIMIT = 9
+

--- a/tweets/services.py
+++ b/tweets/services.py
@@ -1,0 +1,17 @@
+from tweets.models import TweetPhoto
+
+
+class TweetService(object):
+
+    @classmethod
+    def create_photos_from_files(cls, tweet, files):
+        photos = []
+        for index, file in enumerate(files):
+            photo = TweetPhoto(
+                tweet=tweet,
+                user=tweet.user,
+                file=file,
+                order=index,
+            )
+            photos.append(photo)
+        TweetPhoto.objects.bulk_create(photos)


### PR DESCRIPTION
- Added TweetPhoto API into tweets/api (i.e. TweetSerializer and TweetSerializerForCreate) for users to upload up to 9 photos per tweet.
- Ran unit tests (test_create_with_files) for this TweetPhoto API.