### PR TITLE
Add Friendship Pagination

### DIFF
--- a/friendships/api/serializers.py
+++ b/friendships/api/serializers.py
@@ -1,27 +1,43 @@
 from accounts.api.serializers import UserSerializerForFriendship
+from django.contrib.auth.models import User
 from friendships.models import Friendship
+from friendships.services import FriendshipService
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
-from django.contrib.auth.models import User
+
 
 # You can add extra fields to a ModelSerializer
 # or override the default fields by declaring fields on the class,
 # just as you would for a Serializer class by using source=xx.
+# https://www.django-rest-framework.org/api-guide/serializers/#specifying-fields-explicitly
 class FollowerSerializer(serializers.ModelSerializer):
     user = UserSerializerForFriendship(source='from_user')
-    #created_at = serializers.DateTimeField()
+    created_at = serializers.DateTimeField()
+    has_followed = serializers.SerializerMethodField()
 
     class Meta:
         model = Friendship
-        fields = ('user', 'created_at')
+        fields = ('user', 'created_at', 'has_followed')
+
+    def get_has_followed(self, obj):
+        if self.context['request'].user.is_anonymous:
+            return False
+        return FriendshipService.has_followed(self.context['request'].user, obj.from_user)
 
 
 class FollowingSerializer(serializers.ModelSerializer):
     user = UserSerializerForFriendship(source='to_user')
+    created_at = serializers.DateTimeField()
+    has_followed = serializers.SerializerMethodField()
 
     class Meta:
         model = Friendship
-        fields = ('user', 'created_at')
+        fields = ('user', 'created_at', 'has_followed')
+
+    def get_has_followed(self, obj):
+        if self.context['request'].user.is_anonymous:
+            return False
+        return FriendshipService.has_followed(self.context['request'].user, obj.to_user)
 
 
 class FriendshipCreateSerializer(serializers.ModelSerializer):

--- a/friendships/api/tests.py
+++ b/friendships/api/tests.py
@@ -1,11 +1,12 @@
 from friendships.models import Friendship
-from rest_framework.test import APIClient
 from testing.testcases import TestCase
+from utils.paginations import FriendshipPagination
 
 FOLLOW_URL = '/api/friendships/{}/follow/'
 UNFOLLOW_URL = '/api/friendships/{}/unfollow/'
 FOLLOWERS_URL = '/api/friendships/{}/followers/'
 FOLLOWINGS_URL = '/api/friendships/{}/followings/'
+
 
 class FriendshipApiTests(TestCase):
 
@@ -86,23 +87,23 @@ class FriendshipApiTests(TestCase):
         # GET request is okay
         response = self.anonymous_client.get(url)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response.data['following']), 3)
+        self.assertEqual(len(response.data['results']), 3)
         # make sure the info is ordered by "-created_at"
-        ts0 = response.data['following'][0]['created_at']
-        ts1 = response.data['following'][1]['created_at']
-        ts2 = response.data['following'][2]['created_at']
+        ts0 = response.data['results'][0]['created_at']
+        ts1 = response.data['results'][1]['created_at']
+        ts2 = response.data['results'][2]['created_at']
         self.assertEqual(ts0 > ts1, True)
         self.assertEqual(ts1 > ts2, True)
         self.assertEqual(
-            response.data['following'][0]['user']['username'],
+            response.data['results'][0]['user']['username'],
             'user2_following2',
         )
         self.assertEqual(
-            response.data['following'][1]['user']['username'],
+            response.data['results'][1]['user']['username'],
             'user2_following1',
         )
         self.assertEqual(
-            response.data['following'][2]['user']['username'],
+            response.data['results'][2]['user']['username'],
             'user2_following0',
         )
 
@@ -114,16 +115,104 @@ class FriendshipApiTests(TestCase):
         # GET is okay
         response = self.anonymous_client.get(url)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response.data['followers']), 2)
+        self.assertEqual(len(response.data['results']), 2)
         # make sure the info is ordered by "-created_at"
-        ts0 = response.data['followers'][0]['created_at']
-        ts1 = response.data['followers'][1]['created_at']
+        ts0 = response.data['results'][0]['created_at']
+        ts1 = response.data['results'][1]['created_at']
         self.assertEqual(ts0 > ts1, True)
         self.assertEqual(
-            response.data['followers'][0]['user']['username'],
+            response.data['results'][0]['user']['username'],
             'user2_follower1',
         )
         self.assertEqual(
-            response.data['followers'][1]['user']['username'],
+            response.data['results'][1]['user']['username'],
             'user2_follower0',
         )
+
+    def test_followers_pagination(self):
+        max_page_size = FriendshipPagination.max_page_size
+        page_size = FriendshipPagination.page_size
+        for i in range(page_size * 2):
+            follower = self.create_user('user1_follower{}'.format(i))
+            Friendship.objects.create(from_user=follower, to_user=self.user1)
+            if follower.id % 2 == 0:
+                Friendship.objects.create(from_user=self.user2, to_user=follower)
+
+        url = FOLLOWERS_URL.format(self.user1.id)
+        self._test_friendship_pagination(url, page_size, max_page_size)
+
+        # anonymous hasn't followed any users
+        response = self.anonymous_client.get(url, {'page': 1})
+        for result in response.data['results']:
+            self.assertEqual(result['has_followed'], False)
+
+        # user2 has followed users with even id
+        response = self.user2_client.get(url, {'page': 1})
+        for result in response.data['results']:
+            has_followed = (result['user']['id'] % 2 == 0)
+            self.assertEqual(result['has_followed'], has_followed)
+
+    def test_followings_pagination(self):
+        max_page_size = FriendshipPagination.max_page_size
+        page_size = FriendshipPagination.page_size
+        for i in range(page_size * 2):
+            following = self.create_user('user1_following{}'.format(i))
+            Friendship.objects.create(from_user=self.user1, to_user=following)
+            if following.id % 2 == 0:
+                Friendship.objects.create(from_user=self.user2, to_user=following)
+
+        url = FOLLOWINGS_URL.format(self.user1.id)
+        self._test_friendship_pagination(url, page_size, max_page_size)
+
+        # Anonymous hasn't followed any users
+        response = self.anonymous_client.get(url, {'page': 1})
+        for result in response.data['results']:
+            self.assertEqual(result['has_followed'], False)
+
+        # user2 has followed users with even id
+        response = self.user2_client.get(url, {'page': 1})
+        for result in response.data['results']:
+            has_followed = (result['user']['id'] % 2 == 0)
+            self.assertEqual(result['has_followed'], has_followed)
+
+        # user1 has followed all his following users
+        response = self.user1_client.get(url, {'page': 1})
+        for result in response.data['results']:
+            self.assertEqual(result['has_followed'], True)
+
+    def _test_friendship_pagination(self, url, page_size, max_page_size):
+        response = self.anonymous_client.get(url, {'page': 1})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data['results']), page_size)
+        self.assertEqual(response.data['total_pages'], 2)
+        self.assertEqual(response.data['total_results'], page_size * 2)
+        self.assertEqual(response.data['page_number'], 1)
+        self.assertEqual(response.data['has_next_page'], True)
+
+        response = self.anonymous_client.get(url, {'page': 2})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data['results']), page_size)
+        self.assertEqual(response.data['total_pages'], 2)
+        self.assertEqual(response.data['total_results'], page_size * 2)
+        self.assertEqual(response.data['page_number'], 2)
+        self.assertEqual(response.data['has_next_page'], False)
+
+        response = self.anonymous_client.get(url, {'page': 3})
+        self.assertEqual(response.status_code, 404)
+
+        # Test user cannot customize page_size exceeds max_page_size
+        response = self.anonymous_client.get(url, {'page': 1, 'size': max_page_size + 1})
+        self.assertEqual(len(response.data['results']), max_page_size)
+        self.assertEqual(response.data['total_pages'], 2)
+        self.assertEqual(response.data['total_results'], page_size * 2)
+        self.assertEqual(response.data['page_number'], 1)
+        self.assertEqual(response.data['has_next_page'], True)
+
+        # Test user can customize page size by param size
+        response = self.anonymous_client.get(url, {'page': 1, 'size': 2})
+        self.assertEqual(len(response.data['results']), 2)
+        self.assertEqual(response.data['total_pages'], page_size)
+        self.assertEqual(response.data['total_results'], page_size * 2)
+        self.assertEqual(response.data['page_number'], 1)
+        self.assertEqual(response.data['has_next_page'], True)
+

--- a/friendships/api/views.py
+++ b/friendships/api/views.py
@@ -1,18 +1,21 @@
-from rest_framework import viewsets, status
-from rest_framework.decorators import action
-from rest_framework.permissions import IsAuthenticated, AllowAny
-from rest_framework.response import Response
-from friendships.models import Friendship
+from django.contrib.auth.models import User
 from friendships.api.serializers import (
     FollowingSerializer,
     FollowerSerializer,
     FriendshipCreateSerializer
 )
-from django.contrib.auth.models import User
+from friendships.models import Friendship
+from rest_framework import viewsets, status
+from rest_framework.decorators import action
+from rest_framework.permissions import IsAuthenticated, AllowAny
+from rest_framework.response import Response
+from utils.paginations import FriendshipPagination
 
 class FriendshipViewSet(viewsets.GenericViewSet):
     serializer_class = FriendshipCreateSerializer
     queryset = User.objects.all()
+    # Different views may need different pagination settings.
+    pagination_class = FriendshipPagination
 
     # We would like to use POST /api/friendships/1/follow
     # to follow the user with user_id = 1.
@@ -22,20 +25,16 @@ class FriendshipViewSet(viewsets.GenericViewSet):
     def followers(self, request, pk):
         # GET /api/friendships/1/followers/
         friendships = Friendship.objects.filter(to_user_id=pk).order_by('-created_at')
-        serializer = FollowerSerializer(friendships, many=True)
-        return Response(
-            {'followers': serializer.data},
-            status=status.HTTP_200_OK,
-        )
+        page = self.paginate_queryset(friendships)
+        serializer = FollowerSerializer(page, many=True, context={'request': request})
+        return self.get_paginated_response(serializer.data)
 
     @action(methods=['GET'], detail=True, permission_classes=[AllowAny])
     def followings(self, request, pk):
         friendships = Friendship.objects.filter(from_user_id=pk).order_by('-created_at')
-        serializer = FollowingSerializer(friendships, many=True)
-        return Response(
-            {'following': serializer.data},
-            status=status.HTTP_200_OK,
-        )
+        page = self.paginate_queryset(friendships)
+        serializer = FollowingSerializer(page, many=True, context={'request': request})
+        return self.get_paginated_response(serializer.data)
 
     @action(methods=['POST'], detail=True, permission_classes=[IsAuthenticated])
     def follow(self, request, pk):
@@ -56,7 +55,7 @@ class FriendshipViewSet(viewsets.GenericViewSet):
             }, status=status.HTTP_400_BAD_REQUEST)
         instance = serializer.save()
         return Response(
-            FollowingSerializer(instance).data,
+            FollowingSerializer(instance, context={'request': request}).data,
             status=status.HTTP_201_CREATED,
         )
 

--- a/friendships/services.py
+++ b/friendships/services.py
@@ -28,3 +28,10 @@ class FriendshipService(object):
             to_user=user,
         ).prefetch_related('from_user')
         return [friendship.from_user for friendship in friendships]
+
+    @classmethod
+    def has_followed(cls, from_user, to_user):
+        return Friendship.objects.filter(
+            from_user=from_user,
+            to_user=to_user,
+        ).exists()

--- a/utils/paginations.py
+++ b/utils/paginations.py
@@ -1,0 +1,25 @@
+from rest_framework.pagination import PageNumberPagination
+from rest_framework.response import Response
+
+
+class FriendshipPagination(PageNumberPagination):
+    # https://.../api/friendships/1/followers/?page=3&size=10
+
+    # Default page_size
+    page_size = 20
+    # If the default page_size_query_param is None, it won't allow client
+    # to set page_size. page_size_query_param = 'size' means that client
+    # can set different page sizes for different situations (e.g. web vs
+    # mobile requests)
+    page_size_query_param = 'size'
+    # Maximum page_size allowed for client
+    max_page_size = 20
+
+    def get_paginated_response(self, data):
+        return Response({
+            'total_results': self.page.paginator.count,
+            'total_pages': self.page.paginator.num_pages,
+            'page_number':self.page.number,
+            'has_next_page': self.page.has_next(),
+            'results': data,
+        })


### PR DESCRIPTION
- Added rest_framework pagination (utils/pagination) for the friendships API, including pagination for getting followers and followings.
- Added has_followed (in friendships/services.py) in FollowerSerializer and FollowingSerializer so users can check whether a user has been followed.
- Ran unit tests in friendships/api/tests.py for the Friendship Pagination function.